### PR TITLE
refactor `Player` and get unique ID automatically

### DIFF
--- a/app/src/main/java/com/bigyoshi/qrhunt/MainActivity.java
+++ b/app/src/main/java/com/bigyoshi/qrhunt/MainActivity.java
@@ -2,22 +2,15 @@ package com.bigyoshi.qrhunt;
 
 
 import android.Manifest;
-import android.app.ActionBar;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.view.View;
-import android.view.Window;
-import android.view.WindowManager;
-
-import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
-import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.bigyoshi.qrhunt.databinding.ActivityMainBinding;
@@ -29,9 +22,6 @@ public class MainActivity extends AppCompatActivity {
 
     private final int REQUEST_PERMISSIONS_REQUEST_CODE = 1;
     private ActivityMainBinding binding;
-    public static final String SHARED_PREFS = "sharedPrefs";
-    public static final String UNIQUE_KEY = "uniqueKey";
-    private String uniqueKey;
     private Player player;
 
     @Override
@@ -53,27 +43,6 @@ public class MainActivity extends AppCompatActivity {
         // menu should be considered as top level destinations.
         NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_activity_main);
         NavigationUI.setupWithNavController(binding.navView, navController);
-
-        if (!getPlayer()){
-            player = new Player(); // Show generate a unique key that we will save into sharedPrefs
-            uniqueKey = player.getUniqueKey();
-            savePlayer();
-        }
-
-        // Gets the uniqueKey for the Player -> load data by using this key to access the correct
-        // player in the PlayerDataBase
-    }
-
-    public Boolean getPlayer(){
-        SharedPreferences sharedPreferences = getSharedPreferences(SHARED_PREFS, MODE_PRIVATE);
-        uniqueKey = sharedPreferences.getString(UNIQUE_KEY, "");
-        return uniqueKey.compareTo("") != 0;
-    }
-
-    public void savePlayer(){
-        SharedPreferences sharedPreferences = getSharedPreferences(SHARED_PREFS, MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(UNIQUE_KEY, this.uniqueKey);
     }
 
     @Override

--- a/app/src/main/java/com/bigyoshi/qrhunt/Player.java
+++ b/app/src/main/java/com/bigyoshi/qrhunt/Player.java
@@ -1,29 +1,60 @@
 package com.bigyoshi.qrhunt;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.util.UUID;
+
 public class Player {
-    private PlayerInfo pI;
-    private QRLibrary qL;
-    private String playerId;
+    private static final String TAG = Player.class.getSimpleName();
+    private static final String SHARED_PREFS = "sharedPrefs";
+    private static final String PLAYER_ID_PREF = "playerId";
 
-    public Player(){
-        pI = new PlayerInfo();
-        qL = new QRLibrary();
-        uniqueKey = "I am supposed to be unique haha.";
+    private PlayerInfo playerInfo;
+    private QRLibrary qrLibrary;
+    private String playerId = null;
+    private Context context;
+
+    public Player(Context context) {
+        this.context = context;
+        playerInfo = new PlayerInfo();
+        qrLibrary = new QRLibrary();
     }
 
-    public String getUniqueKey(){
-        return this.uniqueKey;
+    public String getPlayerId() {
+        // fetched lazily, but only once
+        if (playerId == null) {
+            SharedPreferences sharedPreferences = context.getSharedPreferences(SHARED_PREFS, Context.MODE_PRIVATE);
+            playerId = sharedPreferences.getString(PLAYER_ID_PREF, "");
+            // generated lazily, only once
+            if (playerId.isEmpty()) {
+                setPlayerId(UUID.randomUUID().toString());
+            }
+        }
+        Log.d(TAG, String.format("retrieved uuid: %s", playerId));
+        return playerId;
     }
 
-    public void deletePlayer(PlayerInfo playerToDelete, Player admin){
+    public void setPlayerId(String id) {
+        // to think about: when the id is changed, it's essentially a new player?
+        playerId = id;
+        SharedPreferences sharedPreferences = context.getSharedPreferences(SHARED_PREFS, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString(PLAYER_ID_PREF, playerId);
+        editor.apply();
+        Log.d(TAG, String.format("set uuid: %s", playerId));
+    }
+
+    public void deletePlayer(PlayerInfo playerToDelete, Player admin) {
         PlayerInfo adminInfo = admin.getPlayerInfo();
-        if (adminInfo.isAdmin()){
+        if (adminInfo.isAdmin()) {
             // Delete Player from database
             adminInfo.deletePlayerInfo(playerToDelete);
         }
     }
 
-    public PlayerInfo getPlayerInfo(){
-        return pI;
+    public PlayerInfo getPlayerInfo() {
+        return playerInfo;
     }
 }

--- a/app/src/main/java/com/bigyoshi/qrhunt/Player.java
+++ b/app/src/main/java/com/bigyoshi/qrhunt/Player.java
@@ -3,7 +3,7 @@ package com.bigyoshi.qrhunt;
 public class Player {
     private PlayerInfo pI;
     private QRLibrary qL;
-    private String uniqueKey;
+    private String playerId;
 
     public Player(){
         pI = new PlayerInfo();


### PR DESCRIPTION
 - I've removed references like `uniqueId` and `userId` in favor of `playerId`. They were ambiguous/inconsistent, and i think userId actually makes more sense but it's more important to be consistent
 - refactored things into the players class. I didn't think the mainactivity should be responsible for eg retrieving from the db. this allerviates that responsibility of the mainactivity. Downside is now player needs a context to operate with (for example, MainActivity subclasses Context, so you can pass `this` to the player to initialize it). I don't _think_ this should be too much of an issue because we'll always have some activity close by to use for the context
 - expanded on shortened names like pI and qL to be consistent

didn't do:
 - flatten the Player/PlayerInfo classes, i think this should be considered as I don't see the benefit of two classes right now