### PR TITLE
ft: PoC top bar total

### DIFF
--- a/app/src/main/java/com/bigyoshi/qrhunt/MainActivity.java
+++ b/app/src/main/java/com/bigyoshi/qrhunt/MainActivity.java
@@ -30,37 +30,37 @@ import androidx.navigation.ui.NavigationUI;
 
 import com.bigyoshi.qrhunt.bottom_navigation.map.MapFragment;
 import com.bigyoshi.qrhunt.databinding.ActivityMainBinding;
+import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
 
 
-public class MainActivity extends AppCompatActivity{
+public class MainActivity extends AppCompatActivity {
 
     private final int REQUEST_PERMISSIONS_REQUEST_CODE = 1;
     private ActivityMainBinding binding;
     private Player player;
     private ImageButton navSearch, navProfile, mapMenu;
     private TextView score;
+    private FirebaseFirestore db;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        binding = ActivityMainBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
 
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
         //Get permissions first
-        requestPermissionsIfNecessary(new String[] {
-                // if you need to show the current location, uncomment the line below
+        requestPermissionsIfNecessary(new String[]{
                 Manifest.permission.ACCESS_FINE_LOCATION,
-                // WRITE_EXTERNAL_STORAGE is required in order to show the map
                 Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                // Required to use the camera
                 Manifest.permission.CAMERA
         });
 
-        binding = ActivityMainBinding.inflate(getLayoutInflater());
-        setContentView(binding.getRoot());
+        db = FirebaseFirestore.getInstance();
 
         Toolbar toolbar = findViewById(R.id.top_nav);
         setSupportActionBar(toolbar);
@@ -69,11 +69,10 @@ public class MainActivity extends AppCompatActivity{
         actionbar.setDisplayShowTitleEnabled(false);
         actionbar.setDisplayShowCustomEnabled(true);
 
-        // Get player
         player = new Player(this);
-        player.getPlayerId(); // Get the id to get the information from the db about the player
 
         score = toolbar.findViewById(R.id.score_on_cam);
+        playerQrCodesRef = db.collection("players").document()
         String scoreText = "Score: " + Integer.toString(player.getPlayerInfo().getQRTotal());
         score.setText(scoreText);
 
@@ -121,13 +120,20 @@ public class MainActivity extends AppCompatActivity{
                     navSearch.setVisibility(View.GONE);
                     mapMenu.setVisibility(View.VISIBLE);
                 }
-                if (navDestination.getId() == R.id.navigation_scanner){
+                if (navDestination.getId() == R.id.navigation_scanner) {
                     navSearch.setVisibility(View.VISIBLE);
                     mapMenu.setVisibility(View.GONE);
 
                 }
             }
         });
+    }
+
+    /*
+    This should be called whenever the user-id changes so that the proper id is is listened to
+     */
+    private void updateFirebaseListeners() {
+
     }
 
     @Override

--- a/app/src/main/java/com/bigyoshi/qrhunt/MainActivity.java
+++ b/app/src/main/java/com/bigyoshi/qrhunt/MainActivity.java
@@ -33,6 +33,7 @@ import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FieldPath;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
@@ -49,6 +50,7 @@ public class MainActivity extends AppCompatActivity {
     private TextView score;
     private FirebaseFirestore db;
     private DocumentReference playerRef;
+    private ListenerRegistration scoreListenerRegistration;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -141,7 +143,10 @@ public class MainActivity extends AppCompatActivity {
      so that the proper id is is listened to for changes
      */
     private void updateFirebaseListeners() {
-//        CollectionReference playerQrCodesRef = db.collection("users").document(player.getPlayerId()).collection("qrCodes");
+        // this isn't really how i want it to be spelled, at all
+        // ideally we can just watch score but this isn't feasible
+        // till i get my cloud functions idea together
+        playerRef = db.collection("users").document(player.getPlayerId());
         CollectionReference playerQrCodesRef = playerRef.collection("qrCodes");
         playerQrCodesRef.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
             @Override
@@ -157,9 +162,10 @@ public class MainActivity extends AppCompatActivity {
                     public void onComplete(@NonNull Task<QuerySnapshot> task) {
                         int total = 0;
                         for (QueryDocumentSnapshot document : task.getResult()) {
-                            total += (int)document.getData().getOrDefault("score", 0);
+                            total += Math.toIntExact((long)document.getData().getOrDefault("value", 0));
                         }
                         Log.d(TAG, String.format("total score: %d", total));
+                        score.setText(String.format("%d points", total));
                     }
                 });
             }

--- a/app/src/main/java/com/bigyoshi/qrhunt/PlayerInfo.java
+++ b/app/src/main/java/com/bigyoshi/qrhunt/PlayerInfo.java
@@ -9,7 +9,7 @@ public class PlayerInfo {
     private Contact contact;
     private Boolean admin;
 
-    public PlayerInfo(){
+    public PlayerInfo() {
         // Automatically generate a random unique username (changed later by Player if they want)
         // QRTotalRank and highestValueQRRank need to be set to the lowest rank so far
         // Contact initialization needed


### PR DESCRIPTION
this is just a proof of concept it can be done in the current state.

Currently, the situation is not ideal, because we require multiple queries to pull the total score. The alternative is letting the client decide numTotal. This is annoying, because now whenever we do a update, insert, or delete, we need to account for all those cases at the call site. 

I also cleaned up the mainactivty a bit.


But with the cloud functions im planning (ie, not in this PR) https://github.com/CMPUT301W22T00/QRHuntCloudFunctions, we can handle update, insert, and delete, all in the same place, and be guarenteed:tm: to catch everything that comes through.

Basically, by decoupling the totalScore, numScanned irresponsibility, I think we greatly improve our reliability.
Oh and I didn't have to write in java so that was nice while it lasted.

The cloud functions are pending testing and rely on a certain schema. The code itself is quite readable and the docs I found were excellent.